### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Playwright Tests
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/welllucky/Services/security/code-scanning/6](https://github.com/welllucky/Services/security/code-scanning/6)

To fix the issue, we need to explicitly set the permissions for the workflow/job. The simplest, least-privilege starting point for workflows that only need to check out code and run tests is `contents: read`, as recommended by CodeQL. This can be set at the workflow root (applies to all jobs without their own block). No other permissions appear necessary for the described steps (testing, uploading artifacts).  
**Steps:**
- In `.github/workflows/playwright.yml`, add the following block at the top level, right after the `name` (before `on:`):  
```yaml
permissions:
  contents: read
```
This restricts GITHUB_TOKEN to read-only access on repository contents, preventing accidental privilege escalation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
