### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/welllucky/Services/security/code-scanning/5](https://github.com/welllucky/Services/security/code-scanning/5)

To fix the problem, you should explicitly set a `permissions` block either globally at the workflow level or for the individual job in the workflow. Since the workflow appears to only read repository contents (actions/checkout and SonarQube scan), the minimal permissions required are `contents: read`. If later you add jobs needing more permissions, you can increase them at that time; but for now, least privilege applies. Insert the following block right after the workflow `name:` and before `on:` (for workflow-wide permissions), or after the job definition and before `runs-on:` (for job-specific permissions). Here, adding at the workflow level is preferred because there is only one job, so all jobs will inherit this minimal set.

You do not need any new imports, method definitions, or other setup—just modify the YAML to include:
```yaml
permissions:
  contents: read
```
on its own line after the workflow name definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
